### PR TITLE
sensations from ropsten (testnet)

### DIFF
--- a/sensum-ethereum/contracts/Sensations.sol
+++ b/sensum-ethereum/contracts/Sensations.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
 import "hardhat/console.sol";
@@ -9,7 +9,7 @@ import "hardhat/console.sol";
 contract Sensations {
 
     struct sensation {
-        string author;
+        uint256 avatar;
         string message;
     }
 
@@ -17,7 +17,7 @@ contract Sensations {
     event Synapsis(sensation _sensation, uint256 _index);
 
     constructor() {
-        console.log("Deploying Sensations contract uWu");
+        console.log("Deploying sensations contract uWu");
     }
 
     function getSensationsLength() public view returns (uint256) {
@@ -32,10 +32,10 @@ contract Sensations {
     // }
 
     // TODO:
-    // Check for author and message lengths.
     // Sanitize input. base64 could be an option to avoid above error as well.
     function newSensation(sensation memory _sensation) public {
-        console.log("Generating new sensation: '%s', '%s'", _sensation.author, _sensation.message);
+        require (bytes(_sensation.message).length <= 512, "too long sensation message");
+        console.log("Generating new sensation: '%s', '%s'", _sensation.avatar, _sensation.message);
         sensations.push(_sensation);
         emit Synapsis(_sensation, sensations.length - 1);
     }

--- a/sensum-pwa/src/blockchain/eth/Ethers.js
+++ b/sensum-pwa/src/blockchain/eth/Ethers.js
@@ -1,11 +1,13 @@
 import { ethers } from 'ethers';
 
 export async function getNetwork(networkUrl) {
-  const provider = new ethers.providers.JsonRpcProvider(networkUrl);
+  const provider = networkUrl === 'ropsten' ?
+   ethers.getDefaultProvider('ropsten') : new ethers.providers.JsonRpcProvider(networkUrl);
   return provider.getNetwork();
 }
 
 export async function getBlockNumber(networkUrl) {
-  const provider = new ethers.providers.JsonRpcProvider(networkUrl);
+  const provider = networkUrl === 'ropsten' ?
+   ethers.getDefaultProvider('ropsten') : new ethers.providers.JsonRpcProvider(networkUrl);
   return provider.getBlockNumber();
 }

--- a/sensum-pwa/src/blockchain/eth/Sensations.js
+++ b/sensum-pwa/src/blockchain/eth/Sensations.js
@@ -18,9 +18,9 @@ const contractJsonAbi = `[
         {
           "components": [
             {
-              "internalType": "string",
-              "name": "author",
-              "type": "string"
+              "internalType": "uint256",
+              "name": "avatar",
+              "type": "uint256"
             },
             {
               "internalType": "string",
@@ -61,9 +61,9 @@ const contractJsonAbi = `[
         {
           "components": [
             {
-              "internalType": "string",
-              "name": "author",
-              "type": "string"
+              "internalType": "uint256",
+              "name": "avatar",
+              "type": "uint256"
             },
             {
               "internalType": "string",
@@ -92,9 +92,9 @@ const contractJsonAbi = `[
       "name": "sensations",
       "outputs": [
         {
-          "internalType": "string",
-          "name": "author",
-          "type": "string"
+          "internalType": "uint256",
+          "name": "avatar",
+          "type": "uint256"
         },
         {
           "internalType": "string",
@@ -108,27 +108,31 @@ const contractJsonAbi = `[
   ]`;
   
 export async function getSensationByIndex (config, index) {
-  const provider = new ethers.providers.JsonRpcProvider(config.networkUrl);
+  const provider = config.networkUrl === 'ropsten' ?
+   ethers.getDefaultProvider('ropsten') : new ethers.providers.JsonRpcProvider(networkUrl);
   const contract = new ethers.Contract(config.sensationsContractAddress, contractJsonAbi, provider);
   const sensationArray = await contract.sensations(index)
-  return {author: sensationArray[0], message: sensationArray[1]};
+  return {avatar: sensationArray[0], message: sensationArray[1]};
 }  
   
 export async function getLatestSensation (config) {
-  const provider = new ethers.providers.JsonRpcProvider(config.networkUrl);
+  const provider = config.networkUrl === 'ropsten' ?
+   ethers.getDefaultProvider('ropsten') : new ethers.providers.JsonRpcProvider(networkUrl);
   const contract = new ethers.Contract(config.sensationsContractAddress, contractJsonAbi, provider);
   const index = await contract.getSensationsLength() - 1;
   return getSensationByIndex(config, index);
 }
 
 export async function getSensationsLength (config) {
-  const provider = new ethers.providers.JsonRpcProvider(config.networkUrl);
+  const provider = config.networkUrl === 'ropsten' ?
+   ethers.getDefaultProvider('ropsten') : new ethers.providers.JsonRpcProvider(networkUrl);
   const contract = new ethers.Contract(config.sensationsContractAddress, contractJsonAbi, provider);
   return contract.getSensationsLength();
 }
 
 export async function newSensation (config, sensation) {
-  const provider = new ethers.providers.JsonRpcProvider(config.networkUrl);
+  const provider = config.networkUrl === 'ropsten' ?
+   ethers.getDefaultProvider('ropsten') : new ethers.providers.JsonRpcProvider(networkUrl);
   const contract = new ethers.Contract(config.sensationsContractAddress, contractJsonAbi, provider);
   // Gets default signer
   const signer = provider.getSigner();

--- a/sensum-pwa/src/blockchain/eth/Sensations.res
+++ b/sensum-pwa/src/blockchain/eth/Sensations.res
@@ -1,16 +1,16 @@
 // Be careful, these methods serve as type checking at rescript level, 
 // but if in runtime returns something different, there will be still a bug!
 
-type sensation = {
-  author: string,
-  message: string
-}
-
 // TODO: Redefine this type
 type confirmedTransaction
 
 // TODO: Redefine this type! Ex. Object { _hex: "0x2b", _isBigNumber: true }
 type bigInt
+
+type sensation = {
+  avatar: bigInt,
+  message: string
+}
 
 @module("./Sensations.js")
 external getSensationByIndex: (~config: State.Configuration.config, ~index: bigInt) => Js.Promise.t<sensation> = "getSensationByIndex"
@@ -25,6 +25,8 @@ external getSensationsLength: (~config: State.Configuration.config) => Js.Promis
 external newSensation: (~config: State.Configuration.config, ~s: sensation) => Js.Promise.t<confirmedTransaction> = "newSensation"
 
 // Old! now you need to pass the config as a parameter too.
+// New format ex:
+// "[1, "Los granujas sean unidos porque ésa es la ley primera. Compartan cerveza verdadera en cualquier tiempo que sea, porque si entre ellos se pelean, los devoran el sinceja."]"
 // Ex. new sensation
 //  let s: Sensations.sensation = {
 //    author: "mk",

--- a/sensum-pwa/src/pages/configuration/Pages_Configuration.res
+++ b/sensum-pwa/src/pages/configuration/Pages_Configuration.res
@@ -36,12 +36,12 @@ let make = () => {
 
     <div className="my-10 grid grid-flow-row gap-3 place-content-center">
       <label htmlFor="networkInput" className="text-xl text-purple-50">
-        {"network"->React.string}
+        {"blockchain network provider"->React.string}
       </label>
       <input
         className="form-control px-2"
         id="networkInput"
-        placeholder="Blockchain Network Provider"
+        placeholder="http://127.0.0.1:8545"
         value=networkUrlInput
         onChange=onChangeNetworkUrlInput
       />

--- a/sensum-pwa/src/state/configuration/State_Configuration.res
+++ b/sensum-pwa/src/state/configuration/State_Configuration.res
@@ -2,8 +2,11 @@ let storage = Dom.Storage2.localStorage
 
 // From executing: npx hardhat run scripts/sensations-deploy.js --network localhost
 // Obs: You can also use an ENS name for the contract address
-let defaultSensationsContractAddress = "0x5FbDB2315678afecb367f032d93F642f64180aa3"
-let defaultUrl = "http://127.0.0.1:8545"
+// let defaultSensationsContractAddress = "0x5FbDB2315678afecb367f032d93F642f64180aa3"
+
+// Deployed tx: https://ropsten.etherscan.io/tx/0x29ef130f4288054c287481356458614b26ebdf98adbf5c521e34f552b81ad02a
+let defaultSensationsContractAddress = "0xb016b0f45dcf44c99804e876aefcc82ea4ed6099"
+let defaultUrl = "ropsten"
 
 type config = {
   sensationsContractAddress: string,


### PR DESCRIPTION
## Historical data
![ropsten](https://user-images.githubusercontent.com/7025445/170890298-fab0854e-4646-4c34-9d22-a08ca992d37e.jpeg)


### Ropsten (ethereum testnet):

- contract deploy: https://ropsten.etherscan.io/address/0xb016b0f45dcf44c99804e876aefcc82ea4ed6099
  - in tx: https://ropsten.etherscan.io/tx/0x29ef130f4288054c287481356458614b26ebdf98adbf5c521e34f552b81ad02a
  -  verification: https://ropsten.etherscan.io/address/0xb016b0f45dcf44c99804e876aefcc82ea4ed6099#code
- 1st sensation: https://ropsten.etherscan.io/tx/0xda35b76da54f931d8fdece547c81221ef65a2384ce28043861fc7ffa710b12c0